### PR TITLE
[Fix] Imports for the docs example to work

### DIFF
--- a/alyahmor/genelex.py
+++ b/alyahmor/genelex.py
@@ -25,16 +25,16 @@
 import itertools
 import pprint
 import pyarabic.araby as araby
-import noun_affixer
-import verb_affixer
-import stopword_affixer
+from .noun_affixer import noun_affixer
+from .verb_affixer import verb_affixer
+from .stopword_affixer import stopword_affixer
 
 class genelex:
     
     def __init__(self,):
-        self.verb_vocalizer = verb_affixer.verb_affixer()        
-        self.noun_vocalizer = noun_affixer.noun_affixer()        
-        self.stopword_vocalizer = stopword_affixer.stopword_affixer()
+        self.verb_vocalizer = verb_affixer()        
+        self.noun_vocalizer = noun_affixer()        
+        self.stopword_vocalizer = stopword_affixer()
         pass
     def generate_by_affixes(self, word, word_type="noun", affixes =[], vocalized=True,):
         """


### PR DESCRIPTION
Greetings,

Thanks for your awesome Arabic packages all through out!

For this one, however, I couldn't just use `python3` to make the docs example work... -Until I explicitly set the imports in the class to be like this in the PR. 